### PR TITLE
Refactor getRandomIndex to get random ID instead

### DIFF
--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -7,7 +7,7 @@ export function showUserData(user) {
     name: document.querySelector('.name'),
     address: document.querySelector('.address'),
     email: document.querySelector('.email'),
-  }
+  };
 
   userInfo.name.innerText = `Name: ${user.name}`;
   userInfo.address.innerText = `Address: ${user.address}`;

--- a/src/model.js
+++ b/src/model.js
@@ -1,13 +1,14 @@
 export function getUserData(users, id) {
+  console.log(id)
   return users.find(user => user.id === id);
 }
 
-function getRandomIndex(array) {
-  return Math.floor(Math.random() * array.length);
+function getRandomID(array) {
+  return Math.floor(Math.random() * array.length) + 1;
 }
 
 export function getRandomUser(users) {
-  return getUserData(users, getRandomIndex(users));
+  return getUserData(users, getRandomID(users));
 }
 
 export function getAllAvgSteps(users) {

--- a/src/model.js
+++ b/src/model.js
@@ -1,5 +1,4 @@
 export function getUserData(users, id) {
-  console.log(id);
   return users.find(user => user.id === id);
 }
 

--- a/src/model.js
+++ b/src/model.js
@@ -1,5 +1,5 @@
 export function getUserData(users, id) {
-  console.log(id)
+  console.log(id);
   return users.find(user => user.id === id);
 }
 
@@ -21,22 +21,26 @@ export function getUserStepGoal(user) {
   return user.dailyStepGoal;
 }
 
-export function getAverageWater(userData) {  
+export function getAverageWater(userData) {
   if (!userData.length) {
-   return 0;
+    return 0;
   }
 
-  return Math.round(userData.reduce((sum, date) => sum + date.numOunces, 0) / userData.length);
+  return Math.round(
+    userData.reduce((sum, date) => sum + date.numOunces, 0) / userData.length,
+  );
 }
 
 export function getDailyWater(hydrationData, id, date) {
-  const userData = hydrationData.find(data => data.userID === id && data.date === date);
+  const userData = hydrationData.find(
+    data => data.userID === id && data.date === date,
+  );
 
   if (!userData) {
     return 0;
   }
 
-  return userData.numOunces
+  return userData.numOunces;
 }
 
 export function getUserHydrationData(hydrationData, id) {
@@ -48,11 +52,10 @@ export function getWeeklyWater(userData) {
     userData = userData.slice(-7);
   }
 
- userData.sort((a,b) => new Date(b.date) - new Date(a.date))
+  userData.sort((a, b) => new Date(b.date) - new Date(a.date));
 
   return userData.reduce((week, day) => {
     week[day.date] = day.numOunces;
     return week;
-  }, {})
+  }, {});
 }
-


### PR DESCRIPTION
What I did: Getting a random index number resulted in a return value of 0-49. Passing in 0 as an id argument to getUserData caused the test to fail because an object with an id of 0 doesn't exist. To account for this, I changed getRandomIndex function to increment the random index number by 1, resulting in a return value of 1-50 for this particular dataset.

Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

Closes #39 