### PR TITLE
Add the split method to only display first name on load

### DIFF
--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -7,7 +7,8 @@ const avgStepsEl = document.querySelector('.avg-steps .steps');
 const usersName = document.querySelector('h2');
 
 export function displayUsersName(user) {
-  usersName.innerText = `Hello, ${user.name}!`;
+  const firstName = user.name.split(' ')[0]
+  usersName.innerText = `Hello, ${firstName}!`;
 }
 
 export function showUserData(user) {


### PR DESCRIPTION
      What I did:
i added a code for only first name to appear on window load.
closes #41 
Did this break anything?

- [ x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ x]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [ x]  If this code needs to be tested, all tests are passing
- [ x]  The code runs locally
- [ x]  There are comments where clarification/ organization is needed
- [ x]  The code is DRY. If it's not, I tried my best
- [ x]  I reviewed my code before pushing

What's next?
Once we get the user data implented we can style that data to match the rest of the app. 
