### PR TITLE
Keep variable store private within function closure

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -30,7 +30,7 @@ export function getAverageWater(userData) {
   }
 
   return Math.round(
-    userData.reduce((sum, date) => sum + date.numOunces, 0) / userData.length
+    userData.reduce((sum, date) => sum + date.numOunces, 0) / userData.length,
   );
 }
 
@@ -39,7 +39,7 @@ export function getCurrentWaterDate(userData) {
 }
 
 export function getDailyWater(userHydrationData, date) {
-  const userData = userHydrationData.find((data) => data.date === date);
+  const userData = userHydrationData.find(data => data.date === date);
 
   if (!userData) {
     return 0;

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -7,46 +7,75 @@ import {
   showUserStepsVsAvg,
   showCurrentDayWaterIntake,
 } from './domUpdates';
-import { getRandomUser, getAllAvgSteps, getDailyWater, getUserData, getCurrentWaterDate} from './model';
+import {
+  getRandomUser,
+  getAllAvgSteps,
+  getDailyWater,
+  getUserData,
+  getCurrentWaterDate,
+} from './model';
 import { getApiData } from './apiCalls';
 
-const store = {
-  apiKeys: {
+function initializeStore() {
+  const store = {
     users: 'https://fitlit-api.herokuapp.com/api/v1/users',
     sleep: 'https://fitlit-api.herokuapp.com/api/v1/sleep',
     hydration: 'https://fitlit-api.herokuapp.com/api/v1/hydration',
     activity: 'https://fitlit-api.herokuapp.com/api/v1/activity',
-  },
-};
+  };
 
-window.onload = initializeApp;
+  return {
+    getAPIKey(endpoint) {
+      return store[endpoint];
+    },
+
+    getKey(key) {
+      return store[key];
+    },
+
+    setKey(key, value) {
+      store[key] = value;
+    },
+  };
+}
+
+let store;
+
+window.onload = () => {
+  store = initializeStore();
+  initializeApp();
+};
 
 function initializeApp() {
   Promise.all([
-    getApiData(store.apiKeys.users, 'users'),
-    getApiData(store.apiKeys.sleep, 'sleepData'),
-    getApiData(store.apiKeys.hydration, 'hydrationData'),
-    getApiData(store.apiKeys.activity, 'activityData'),
+    getApiData(store.getAPIKey('users'), 'users'),
+    getApiData(store.getAPIKey('sleep'), 'sleepData'),
+    getApiData(store.getAPIKey('hydration'), 'hydrationData'),
+    getApiData(store.getAPIKey('activity'), 'activityData'),
   ])
     .then(values => {
       const [users, sleepData, hydrationData, activityData] = values;
-      store.userData = users;
-      store.sleepData = sleepData;
-      store.hydrationData = hydrationData;
-      store.activityData = activityData;
+      store.setKey('userData', users);
+      store.setKey('sleepData', sleepData);
+      store.setKey('hydrationData', hydrationData);
+      store.setKey('activityData', activityData);
     })
     .then(processUserData);
 }
 
 function processUserData() {
-  store.user = getRandomUser(store.userData);
-  const userSteps = store.user.dailyStepGoal;
-  const avg = getAllAvgSteps(store.userData);
-  const userHydrationData = getUserData('hydrationData', store.hydrationData, store.user.id);
-  const todaysWaterIntake = getDailyWater(userHydrationData, getCurrentWaterDate(userHydrationData));
-  showCurrentDayWaterIntake(todaysWaterIntake);
-  showUserData(store.user);
+  const userData = store.getKey('userData');
+  store.setKey('user', getRandomUser(userData));
+  const userSteps = store.getKey('user').dailyStepGoal;
+  const avg = getAllAvgSteps(userData);
+  const userHydrationData = getUserData(
+    'hydrationData',
+    store.getKey('hydrationData'),
+    store.getKey('user').id,
+  );
+  showCurrentDayWaterIntake(getDailyWater(userHydrationData, '2023/03/31'));
+  showUserData(store.getKey('user'));
   showUserStepsVsAvg(userSteps, avg);
-  displayUsersName(store.user);
+  displayUsersName(store.getKey('user'));
   showWeeklyWaterIntake(userHydrationData);
 }

--- a/test/UserRepository-test.js
+++ b/test/UserRepository-test.js
@@ -41,7 +41,7 @@ describe('user data functions', () => {
   it("should return a user's step goal", () => {
     expect(stepGoal).to.equal(6000);
   });
-  
+
   it('should return the average of all step goals', () => {
     expect(average).to.equal(6000);
   });
@@ -49,7 +49,6 @@ describe('user data functions', () => {
   it('should return a random user object from the array', () => {
     expect(sampleData.users).to.deep.include(user);
   });
-
 });
 
 describe('hydrationData', () => {
@@ -123,15 +122,15 @@ describe('hydrationData', () => {
     const userData = getUserData('hydrationData', hydrationData, 2);
     const water = getWeeklyWater(userData);
 
-    expect(water).to.deep.equal({'2023/03/24': 35 });
+    expect(water).to.deep.equal({ '2023/03/24': 35 });
   });
-  
+
   it('should return an empty object is only 1 data point exists', () => {
     const userData = getUserData('hydrationData', hydrationData, 3);
     const water = getWeeklyWater(userData);
 
     expect(water).to.deep.equal({});
-  })
+  });
 
   it('should return an empty object if no user data exists', () => {
     const userData = getUserData('hydrationData', hydrationData, 3);
@@ -171,7 +170,7 @@ describe('sleepData', () => {
   it('should return how many hours a user slept for a specific day', () => {
     const userData = getUserData('sleepData', sleep, 2);
     const sleeps = getDailySleep(userData, '2023/03/25');
-  
+
     expect(sleeps).to.equal(8.4);
   });
 
@@ -179,6 +178,6 @@ describe('sleepData', () => {
     const userData = getUserData('sleepData', sleep, 2);
     const sleeps = getSleepQuality(userData, '2023/03/25');
 
-    expect(sleeps).to.equal(3.5)
-  })
+    expect(sleeps).to.equal(3.5);
+  });
 });


### PR DESCRIPTION
What I did: I refactored the initialization of the variable store to occur after the window load event listener is triggered. A function is invoked and assigned to a public store variable. The store's variables created during the initialization function invocation are kept private via JavaScript's closure behavior. The function returns methods that are used to read and update the private store variables.

Closes #56 

Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

What's next? There could be some closures incorporated into other model.js functions. 

